### PR TITLE
Night Mode in SideBar 1.0

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,6 +2,10 @@
   --primary-color: #1976d2;
   --hover-color: #13508d;
   --light-color: #fff;
+  --dark-color: #272727;
+  --dark-theme-primary-color: #3f95eb;
+  --dark-light-color: #efefef;
+  --black-color: #000;
 }
 
 .App {
@@ -12,6 +16,7 @@
 body {
   margin: 0;
   padding: 0;
+  transition: all .2s ease;
 }
 
 * {
@@ -74,13 +79,120 @@ a {
 
 .sidebar-link {
   color: var(--primary-color);
-  background-color: var(--light-color);
+  background-color: transparent;
   transition: all .2s ease;
 }
-
 
 .sidebar-link:hover {
   color: var(--light-color);
   background-color: var(--primary-color);
   transform: translateX(25px);
+}
+
+.dark-mode-label {
+  transition: all .2s ease;
+  transform-origin: center;
+}
+
+.dark-mode-icon {
+  transition: all .4s ease;
+  transform-origin: center;
+}
+
+.dark-mode-icon input {
+  opacity: 0;
+}
+
+.dark-mode-label:hover {
+  color: var(--primary-color);
+}
+
+.dark-mode-label:hover .dark-mode-icon {
+  transform: rotate(360deg) translateX(3px);
+  background-color: var(--primary-color);
+  color: var(--light-color);
+}
+
+.dark-theme {
+  color: var(--dark-light-color) !important;
+  background-color: var(--dark-color);
+  transition: all .2s ease;
+}
+
+.dark-theme .css-zxtyt4-MuiPaper-root-MuiAppBar-root {
+  color: var(--dark-light-color) !important;
+}
+
+.dark-theme .dark-mode-label input:checked~svg {
+  background-color: var(--primary-color);
+}
+
+.dark-theme label {
+  color: var(--dark-light-color) !important;
+}
+
+.dark-theme .dark-mode-label input~svg {
+  transition: all .4s ease;
+}
+
+@media screen and (max-width: 600px) {
+  .dark-theme .dark-mode-label {
+    color: var(--dark-light-color) !important;
+  }
+
+  .dark-theme .dark-mode-label input:checked~svg {
+    color: var(--dark-light-color) !important;
+  }
+
+  .dark-theme .dark-mode-label:hover input:checked~svg {
+    color: var(--dark-color) !important;
+  }
+
+  .dark-theme .dark-mode-label:hover .dark-mode-icon,
+  .dark-mode-label:hover .dark-mode-icon {
+    transform: translateX(0) !important;
+  }
+
+  .dark-theme .MuiDrawer-paper {
+    background-color: var(--dark-color);
+  }
+
+}
+
+.dark-theme .MuiDrawer-paper {
+  border-right: 1px solid var(--black-color) !important;
+}
+
+.dark-theme .dark-mode-label:hover {
+  color: var(--dark-theme-primary-color) !important;
+}
+
+.dark-theme .dark-mode-label:hover .dark-mode-icon {
+  transform: rotate(360deg) translateX(3px);
+  background-color: var(--dark-light-color) !important;
+  color: var(--dark-theme-primary-color) !important;
+}
+
+.dark-theme .dark-mode-label:hover input:checked~svg {
+  background-color: var(--dark-light-color) !important;
+}
+
+.dark-theme .MuiDrawer-paper>div>ul>a>li {
+  border-bottom: 1px solid var(--black-color) !important;
+}
+
+.dark-theme .MuiDrawer-paper>div>ul>a:hover {
+  color: var(--dark-light-color);
+}
+
+.dark-theme .sidebar-link:hover {
+  color: var(--dark-light-color);
+}
+
+.dark-theme hr {
+  border-color: var(--black-color);
+}
+
+.dark-theme footer {
+  border-top: 1px solid var(--black-color);
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,3 @@
-import Sidebar from "./Components/Sidebar";
 import Footer from "./Components/Footer";
 import './App.css';
 import { Routes, Route, useLocation } from "react-router-dom";

--- a/src/Components/ResponsiveSidebar.js
+++ b/src/Components/ResponsiveSidebar.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React, { useState } from 'react';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
 import CssBaseline from '@mui/material/CssBaseline';
@@ -10,13 +10,15 @@ import ListItem from '@mui/material/ListItem';
 import MenuIcon from '@mui/icons-material/Menu';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
+import InputLabel from '@mui/material/InputLabel';
+import DarkModeIcon from '@mui/icons-material/DarkMode';
 import { SidebarData } from './SidebarData';
 import { Link } from 'react-router-dom';
-import { Colors } from '../Styles/Styles';
 
 const drawerWidth = 240;
 
 export default function ResponsiveSidebar(props, { pageComponent }) {
+
     const { window } = props;
     const [mobileOpen, setMobileOpen] = React.useState(false);
 
@@ -24,14 +26,44 @@ export default function ResponsiveSidebar(props, { pageComponent }) {
         setMobileOpen(!mobileOpen);
     };
 
-    const { primary, light, dark, lightDark } = Colors;
+    //nightmode functionality
+    let [nightMode, setNightMode] = useState(false);
+    nightMode === true ? document.body.classList.add('dark-theme') : document.body.classList.remove('dark-theme');
+
+    //nightmode function
+    const addNightModeToBody = () => {
+        nightMode === true ? setNightMode(false) : setNightMode(true);
+    }
 
     const drawer = (
         <div>
-            <Toolbar />
+            <Toolbar>
+                <Box component='div' sx={{ display: 'flex', alignItems: 'center' }}>
+                    <InputLabel className='dark-mode-label' sx={{ p: 2, cursor: 'pointer', display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 1 }}>NightMode
+                        <Box
+                            component='span'
+                            className='dark-mode-icon'
+                            sx={{
+                                display: 'flex',
+                                justifyContent: 'center',
+                                alignItems: 'center',
+                                backgroundColor: '#efefef',
+                                borderRadius: '50%',
+                                p: 1
+                            }}>
+                            <input type='checkbox' onChange={addNightModeToBody} />
+                            <DarkModeIcon sx={{ position: 'absolute', borderRadius: '50%', p: 1, fontSize: '2rem' }} />
+                        </Box>
+                    </InputLabel>
+                </Box>
+            </Toolbar>
             <Divider />
             <List
-                sx={{ border: 'none', p: 0 }}
+                sx={{
+                    border: 'none',
+                    p: 0,
+                    backgroundColor: 'transparent'
+                }}
             >
                 {
                     //sidebar datat bemappelem
@@ -111,7 +143,7 @@ export default function ResponsiveSidebar(props, { pageComponent }) {
                     variant="permanent"
                     sx={{
                         display: { xs: 'none', sm: 'block' },
-                        '& .MuiDrawer-paper': { boxSizing: 'border-box', width: drawerWidth },
+                        '& .MuiDrawer-paper': { boxSizing: 'border-box', width: drawerWidth, backgroundColor: 'transparent' },
                     }}
                     open
                 >

--- a/src/Components/ResponsiveSidebar.js
+++ b/src/Components/ResponsiveSidebar.js
@@ -39,7 +39,8 @@ export default function ResponsiveSidebar(props, { pageComponent }) {
         <div>
             <Toolbar>
                 <Box component='div' sx={{ display: 'flex', alignItems: 'center' }}>
-                    <InputLabel className='dark-mode-label' sx={{ p: 2, cursor: 'pointer', display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 1 }}>NightMode
+                    <InputLabel className='dark-mode-label' sx={{ p: 2, cursor: 'pointer', display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 1 }}>
+                        Dark Mode :
                         <Box
                             component='span'
                             className='dark-mode-icon'
@@ -77,6 +78,7 @@ export default function ResponsiveSidebar(props, { pageComponent }) {
 
                             <Link
                                 to={path}
+                                onClick={handleDrawerToggle}
                             >
                                 <ListItem className='row sidebar-link' sx={{ padding: 2, borderBottom: '1px solid rgba(0, 0, 0, 0.12)' }}>
                                     <Box component='div' id='icon'>{icon}</Box>
@@ -114,7 +116,7 @@ export default function ResponsiveSidebar(props, { pageComponent }) {
                         <MenuIcon />
                     </IconButton>
                     <Typography variant="h6" noWrap component="div">
-                        Pénzes Bálint CV
+                        CV of Bálint Pénzes
                     </Typography>
                 </Toolbar>
             </AppBar>


### PR DESCRIPTION
Szevasz Bálint!

Hozzáadtam egy responsive night mode switchert az oldalhoz, amit a headerben találsz. A hold ikonra kattintva az oldal átvált egy ún. "éjszakai módba", ami csökkentett fényviszonyok mellett sokkal kíméletesebben bánik a felhasználó látásával. Ez akkor hasznos, ha valaki éppen este, vagy sötét körülmények között szeretné megnézni a CV-det.

A switcher használható mobilon is. Mobilon hozzáadtam egy functiont a sidebar linkekhez, ami egyszerűen bezárja a menüt miután rákattintottál az adott aloldalra.